### PR TITLE
Fix keymap by adding CKC_00 combo

### DIFF
--- a/keymaps/hmasdevmap/keymap.c
+++ b/keymaps/hmasdevmap/keymap.c
@@ -40,6 +40,8 @@ enum cutom_keycodes {
     /* PYTHON COMMENT */
     CKC_PY_NOQA,
     CKC_PY_TYPE_IGNORE,
+    /* others */
+    CKC_00,
     /* SAFE RANGE */
     HM_SAFE_RANGE,
 };
@@ -70,6 +72,8 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         // PYTHON COMMENT
         case CKC_PY_NOQA: if (record->event.pressed) { SEND_STRING("  # noqa"); } return false; break;
         case CKC_PY_TYPE_IGNORE: if (record->event.pressed) { SEND_STRING("  # type' ignore"); } return false; break;
+        // others
+        case CKC_00: if (record->event.pressed) { SEND_STRING("00"); } return false; break;
         default: return true; break;
     };
     return true;
@@ -133,6 +137,9 @@ const uint16_t PROGMEM KC_HOME_LEFT[] = {KC_HOME, KC_LEFT, COMBO_END};
 const uint16_t PROGMEM KC_TAB_COMM[] = {LSFT_T(KC_TAB), LT(KL_OPE, KC_COMM), COMBO_END};
 const uint16_t PROGMEM KC_GRV_SPACE[] = {LALT_T(KC_GRV), LT(KL_FUN, KC_SPACE), COMBO_END};
 
+const uint16_t PROGMEM CKC_00_KC_0[] = {CKC_00, KC_0, COMBO_END};
+const uint16_t PROGMEM CKC_00_KC_1[] = {CKC_00, KC_1, COMBO_END};
+
 const uint16_t PROGMEM KC_QWER[] = {LCTL_T(KC_Q), KC_W, KC_E, KC_R, COMBO_END};
 const uint16_t PROGMEM KC_QWDF[] = {LCTL_T(KC_Q), KC_W, KC_D, KC_F, COMBO_END};
 
@@ -152,6 +159,9 @@ combo_t key_combos[] = {
 
     COMBO(KC_TAB_COMM, MO(KL_SYMNUM)),
     COMBO(KC_GRV_SPACE, MO(KL_SYMNUM)),
+
+    COMBO(CKC_00_KC_0, KC_BSPC),
+    COMBO(CKC_00_KC_1, KC_ENT),
 
     COMBO(KC_QWER, DF(KL_NORMAN)),     // qwerty
     COMBO(KC_QWDF, DF(KL_QWERTY)),     // mod norman
@@ -197,6 +207,6 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         LCTL(KC_MINS),       RCS(KC_SCLN),        RCS(KC_ESC),         LSG(KC_LEFT),        LSG(KC_RGHT),        LSFT(KC_MINS),       KC_7,                KC_8,                KC_9,                LSFT(KC_QUOT),
         LSFT(KC_1),          LSFT(KC_SLSH),       LSFT(KC_EQL),        LSFT(KC_6),          LSFT(KC_INT3),       KC_DOT,              KC_4,                KC_5,                KC_6,                KC_SLSH,
         LSFT(KC_LBRC),       CKC_L_ARROW,         CKC_R_ARROW,         LSFT(KC_5),          LSFT(KC_4),          KC_0,                KC_1,                KC_2,                KC_3,                LSFT(KC_SCLN),
-        LSFT(KC_3),          XXXXXXX,             XXXXXXX,             XXXXXXX,             TD(TD_3_QUOTE),      KC_BSPC,             XXXXXXX,             XXXXXXX,             XXXXXXX,             KC_MINS
+        LSFT(KC_3),          XXXXXXX,             XXXXXXX,             XXXXXXX,             TD(TD_3_QUOTE),      CKC_00,              XXXXXXX,             XXXXXXX,             XXXXXXX,             KC_MINS
     )
 };


### PR DESCRIPTION
This pull request fixes the keymap by adding the CKC_00 combo. The CKC_00 combo allows the user to input "00" when the CKC_00 key is pressed. This change ensures that the keymap is updated and functioning correctly.