### PR TITLE
Add compile firmware workflow call

### DIFF
--- a/.github/workflows/compile-firmware-on-push.yaml
+++ b/.github/workflows/compile-firmware-on-push.yaml
@@ -1,0 +1,14 @@
+name: Compile On Push
+
+on:
+  push:
+    tags:
+    branches:
+      - "main"
+
+jobs:
+  Compile Firmware:
+    uses: ./.github/workflows/compile-firmware-workflow-call.yaml
+    with:
+      git-ref: ${{ github.ref }}
+      keymap: "default"

--- a/.github/workflows/compile-firmware-workflow-call.yaml
+++ b/.github/workflows/compile-firmware-workflow-call.yaml
@@ -1,0 +1,63 @@
+name: Compile Firmware
+
+on:
+  workflow_dispatch:
+    inputs:
+      git-ref:
+        required: false
+        type: string
+        default: "main"
+        description: "Git ref to checkout. Default is main."
+      keymap:
+        type: string
+        required: false
+        default: "default"
+        description: "Keymap name. Default is default."
+  workflow_call:
+    inputs:
+      git-ref:
+        required: false
+        type: string
+        default: "main"
+        description: "Git ref to checkout. Default is main."
+      keymap:
+        type: string
+        required: false
+        default: "default"
+        description: "Keymap name. Default is default."
+
+jobs:
+  Compile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.git-ref }}
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install QMK
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --user qmk
+      - name: Setup QMK
+        run: |
+          qmk setup -H ~/qmk_firmware -y
+      - name: Copy my keyboards into qmk_firmsware
+        run: |
+          mkdir -p ~/qmk_firmware/keyboards/hmproto34
+          cp -r ./* ~/qmk_firmware/keyboards/hmproto34 || echo 'failed to copy'
+      - name: Compile
+        run: |
+          cd ~/qmk_firmware
+          qmk compile -kb "${KEYBOARD_NAME}" -km "${KEYMAP_NAME}"
+        env:
+          KEYBOARD_NAME: "hmproto34"
+          KEYMAP_NAME: ${{ github.event.inputs.keymap }}
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: hmproto34-${{ github.event.inputs.keymap }}
+          path: ~/qmk_firmware/.build


### PR DESCRIPTION
This pull request adds a compile firmware workflow call to the repository. The workflow is triggered on push to the main branch and compiles the firmware using QMK. It also includes a workflow_dispatch event that allows manual triggering of the workflow with optional inputs for the git ref and keymap. The compiled firmware artifacts are uploaded as artifacts.