### PR TITLE
Update compile firmware workflow call and create artifacts directory

### DIFF
--- a/.github/workflows/compile-firmware-on-push.yaml
+++ b/.github/workflows/compile-firmware-on-push.yaml
@@ -11,4 +11,4 @@ jobs:
     uses: ./.github/workflows/compile-firmware-workflow-call.yaml
     with:
       git-ref: ${{ github.ref }}
-      keymap: "default"
+      keymap: default

--- a/.github/workflows/compile-firmware-workflow-call.yaml
+++ b/.github/workflows/compile-firmware-workflow-call.yaml
@@ -56,8 +56,16 @@ jobs:
         env:
           KEYBOARD_NAME: "hmproto34"
           KEYMAP_NAME: ${{ github.event.inputs.keymap }}
+      - name: Create Artifacts Directory
+        run: |
+          mkdir -p ~/artifacts
+          cp ${KEYBOARD_NAME}_${KEYMAP_NAME}.hex ~/artifacts/
+          cp ./LICENSE ~/artifacts/
+        env:
+          KEYBOARD_NAME: "hmproto34"
+          KEYMAP_NAME: ${{ github.event.inputs.keymap }}
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
           name: hmproto34-${{ github.event.inputs.keymap }}
-          path: ~/qmk_firmware/.build
+          path: ~/artifacts


### PR DESCRIPTION
This pull request updates the compile firmware workflow call to use the default value for the keymap and creates an artifacts directory. The artifacts directory is used to store the compiled firmware hex file and the LICENSE file.