### PR TITLE
Update compile firmware workflow to create artifacts directory

### DIFF
--- a/.github/workflows/compile-firmware-workflow-call.yaml
+++ b/.github/workflows/compile-firmware-workflow-call.yaml
@@ -55,7 +55,7 @@ jobs:
           qmk compile -kb "${KEYBOARD_NAME}" -km "${KEYMAP_NAME}"
         env:
           KEYBOARD_NAME: "hmproto34"
-          KEYMAP_NAME: ${{ github.event.inputs.keymap }}
+          KEYMAP_NAME: ${{ inputs.keymap }}
       - name: Create Artifacts Directory
         run: |
           mkdir -p ~/artifacts
@@ -63,9 +63,9 @@ jobs:
           cp ./LICENSE ~/artifacts/
         env:
           KEYBOARD_NAME: "hmproto34"
-          KEYMAP_NAME: ${{ github.event.inputs.keymap }}
+          KEYMAP_NAME: ${{ inputs.keymap }}
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: hmproto34-${{ github.event.inputs.keymap }}
+          name: hmproto34-${{ inputs.keymap }}
           path: ~/artifacts


### PR DESCRIPTION
This pull request updates the compile firmware workflow to create an artifacts directory. Previously, the workflow did not create this directory, which caused issues when trying to access the compiled firmware files. With this update, the workflow will now create the artifacts directory and copy the necessary files into it. This will ensure that the compiled firmware files are easily accessible for further use.