### PR TITLE
Update GitHub Actions workflow to use tag instead of git-ref

### DIFF
--- a/.github/workflows/update-version-on-push-tag.yaml
+++ b/.github/workflows/update-version-on-push-tag.yaml
@@ -11,7 +11,7 @@ jobs:
   validate-version:
     uses: ./.github/workflows/validate-version-workflow-call.yaml
     with:
-      git-ref: ${{ github.ref }}
+      tag: ${{ github.ref }}
   update-version:
     needs: [validate-version]
     if: ${{ failure() }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to use the tag instead of the git-ref. This change ensures that the correct version is used in the workflow.