### PR TITLE
Fix typo in GitHub Actions workflow

### DIFF
--- a/.github/workflows/upload-assets-on-release.yaml
+++ b/.github/workflows/upload-assets-on-release.yaml
@@ -12,7 +12,7 @@ jobs:
       keymap: "default"
   up:
     needs: [build]
-    if: ${{ succdss() }}
+    if: ${{ success() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
This pull request fixes a typo in the GitHub Actions workflow file. The typo caused a syntax error and prevented the workflow from running successfully. This PR corrects the typo and ensures that the workflow runs without any issues.