### PR TITLE
Update asset path and name in upload-assets-on-release.yaml

### DIFF
--- a/.github/workflows/upload-assets-on-release.yaml
+++ b/.github/workflows/upload-assets-on-release.yaml
@@ -22,8 +22,8 @@ jobs:
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./hmproto34-default.zip
-          asset_name: hmproto34-default.zip
+          asset_path: ./hmproto34-default.hex
+          asset_name: hmproto34-default.hex
           asset_content_type: application/octet-stream
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the asset path and name in the `upload-assets-on-release.yaml` file. The previous asset path and name were `./hmproto34-default.zip` and `hmproto34-default.zip` respectively. The new asset path and name are `./hmproto34-default.hex` and `hmproto34-default.hex` respectively. This change ensures that the correct asset is uploaded during the release process.