### PR TITLE
Update asset path and name in upload-assets-on-release.yaml

### DIFF
--- a/.github/workflows/upload-assets-on-release.yaml
+++ b/.github/workflows/upload-assets-on-release.yaml
@@ -18,11 +18,15 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: hmproto34-default
+      - name: Unzip Release Asset
+        run: |
+          unzip /home/runner/work/hmproto34/hmproto34/hmproto34-default.zip
+          ls -la /home/runner/work/hmproto34/hmproto34/hmproto34-default
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: /home/runner/work/hmproto34/hmproto34/hmproto34-default.hex # TODO: change this path
+          asset_path: /home/runner/work/hmproto34/hmproto34/hmproto34-default/hmproto34-default.hex # TODO: change this path
           asset_name: hmproto34-default.hex
           asset_content_type: application/octet-stream
         env:


### PR DESCRIPTION
This pull request updates the asset path and name in the `upload-assets-on-release.yaml` file. Previously, the asset path was set to `/home/runner/work/hmproto34/hmproto34/hmproto34-default.hex` and the asset name was set to `hmproto34-default.hex`. This PR changes the asset path to `/home/runner/work/hmproto34/hmproto34/hmproto34-default/hmproto34-default.hex` to match the updated file structure.