### PR TITLE
Fix key combo for KC_F4_F5 in keymap.c

### DIFF
--- a/keymaps/hmasdevmap/keymap.c
+++ b/keymaps/hmasdevmap/keymap.c
@@ -171,7 +171,7 @@ const uint16_t PROGMEM KC_F1_F2_F3[] = {KC_F1, KC_F2, KC_F3, COMBO_END};
 const uint16_t PROGMEM KC_F2_F3_F4[] = {KC_F2, KC_F3, KC_F4, COMBO_END};
 const uint16_t PROGMEM KC_F1_F2_F3_F4[] = {KC_F1, KC_F2, KC_F3, KC_F4, COMBO_END};
 const uint16_t PROGMEM KC_F3_F4[] = {KC_F3, KC_F4, COMBO_END};
-const uint16_t PROGMEM KC_F4_F5[] = {KC_F3, KC_F4, COMBO_END};
+const uint16_t PROGMEM KC_F4_F5[] = {KC_F4, KC_F5, COMBO_END};
 const uint16_t PROGMEM KC_F3_F4_F5[] = {KC_F3, KC_F4, KC_5, COMBO_END};
 
 combo_t key_combos[] = {


### PR DESCRIPTION
This pull request fixes the key combo for KC_F4_F5 in the keymap.c file. Previously, the combo was incorrectly defined as KC_F3 and KC_F4, but it has been corrected to KC_F4 and KC_F5. This ensures that the correct key combination is registered and functions as intended.