### PR TITLE
Add GitHub Actions workflow to sync with hmproto34s repository

### DIFF
--- a/.github/workflows/sync-with-hmproto34s.yaml
+++ b/.github/workflows/sync-with-hmproto34s.yaml
@@ -1,0 +1,53 @@
+name: syncronize with hmproto34
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "5 17 * * *"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Sync
+        run: |
+          chmod +x sync-with-hmproto34s.sh
+          ./sync-with-hmproto34s.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for Changes
+        run: |
+          if [[ -n $(git status --porcelain keymaps) ]]; then
+            echo "keymaps has changed."
+            echo "changes_detected=true" >> "$GITHUB_ENV"
+          else
+            echo "keymaps has not changed."
+            echo "changes_detected=false" >> "$GITHUB_ENV"
+          fi
+      - name: Commit Changes
+        if: env.changes_detected == 'true'
+        run: |
+          git checkout -b sync-with-hmproto34s
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add keymaps
+          git status
+          git commit -m "Sync with hmproto34s"
+      - name: Push Changes
+        if: env.changes_detected == 'true'
+        run: |
+          git push -u origin sync-with-hmproto34s
+      - name: Create Pull Request
+        if: env.changes_detected == 'true'
+        run: |
+          gh pr create  \
+              --title "Sync with hmproto34s" \
+              --body "Sync with hmproto34s" \
+              --base main \
+              --head sync-with-hmproto34s \
+              --assignee hmasdev \
+              --reviewer hmasdev \
+              --label "bot"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/sync-with-hmproto34s.sh
+++ b/sync-with-hmproto34s.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+git clone https://github.com/hmasdev/hmproto34s.git ./hmproto34s
+cp hmproto34s/keymaps/default/keymap.c ./keymaps/default/keymap.c
+cp hmproto34s/keymaps/default/keymap.c ./keymaps/vial/keymap.c
+cp -r hmproto34s/keymaps/hmasdevmap ./keymaps/
+rm -rf hmproto34s


### PR DESCRIPTION
This pull request adds a GitHub Actions workflow that syncs with the hmproto34s repository. The workflow runs on a schedule and checks for changes in the keymaps directory. If changes are detected, the workflow commits and pushes the changes to a new branch, and creates a pull request with the title "Sync with hmproto34s". The pull request is assigned to and reviewed by hmasdev, and labeled as "bot".