### PR TITLE
Fix key combos and add new combo for quote

### DIFF
--- a/keymaps/hmasdevmap/keymap.c
+++ b/keymaps/hmasdevmap/keymap.c
@@ -175,6 +175,8 @@ const uint16_t PROGMEM KC_F3_F4[] = {KC_F3, KC_F4, COMBO_END};
 const uint16_t PROGMEM KC_F4_F5[] = {KC_F4, KC_F5, COMBO_END};
 const uint16_t PROGMEM KC_F3_F4_F5[] = {KC_F3, KC_F4, KC_5, COMBO_END};
 
+const uint16_t PROGMEM KC_TD_QUOTE_CKC_NNN[] = {TD(TD_QUOTE), CKC_NNN, COMBO_END};
+
 combo_t key_combos[] = {
     // python
     COMBO(KC_F2_F3, CKC_PYTHON),
@@ -233,6 +235,9 @@ combo_t key_combos[] = {
     // for default layer change
     COMBO(KC_QWER, DF(KL_NORMAN)),     // qwerty
     COMBO(KC_QWDF, DF(KL_QWERTY)),     // mod norman
+
+    // combo for mouse
+    COMBO(KC_TD_QUOTE_CKC_NNN, KC_BTN1),
 };
 /* combo end */
 


### PR DESCRIPTION
This pull request fixes the key combos and adds a new combo for the quote key. The previous key combos were not functioning correctly, and this PR addresses that issue. Additionally, a new combo has been added for the quote key, which will trigger the KC_BTN1 action.