### PR TITLE
Update upload-artifact action to v4

### DIFF
--- a/.github/workflows/compile-firmware-workflow-call.yaml
+++ b/.github/workflows/compile-firmware-workflow-call.yaml
@@ -65,7 +65,7 @@ jobs:
           KEYBOARD_NAME: "hmproto34"
           KEYMAP_NAME: ${{ inputs.keymap }}
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: hmproto34-${{ inputs.keymap }}
           path: ./artifacts


### PR DESCRIPTION
This pull request updates the `upload-artifact` action to version 4. This update ensures that the latest features and bug fixes are available for artifact uploading.

#38